### PR TITLE
Use default template directory

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 	"license-name": "CC0-1.0",
 	"type": "skin",
 	"requires": {
-		"MediaWiki": ">= 1.36.0"
+		"MediaWiki": ">= 1.37.0"
 	},
 	"ValidSkinNames": {
 		"lift": {
@@ -16,7 +16,6 @@
 			"args": [ {
 				"name": "Lift",
 				"responsive" : true,
-				"templateDirectory": "skins/Lift/templates",
 				"messages": [
 				],
 				"styles": [


### PR DESCRIPTION
This currently throws a deprecation notice on extension setup. See https://phabricator.wikimedia.org/T262067 for more context. By default the folder is the templates folder so this is no longer needed.